### PR TITLE
fix: overlapping on mobile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@ onMounted(() => {
 
 <template>
   <div class="relative flex items-top justify-center min-h-screen bg-gray-50 dark:bg-transparent sm:items-center sm:pt-0">
-    <div class="fixed top-0 right-0 px-6 py-4 block font-light">
+    <div class="absolute top-0 right-0 px-6 py-4 block font-light">
       <a href="http://e-learning.md.chula.ac.th" target="_blank" class="text-sm text-gray-500 dark:text-gray-400 underline">MDCU E-Learning</a>
     </div>
 


### PR DESCRIPTION
Example from Safari (iPhone 12)
![overlap](https://user-images.githubusercontent.com/39715559/209415680-e31e79db-2208-4caf-8dfa-68d6419dc48f.jpg)
